### PR TITLE
Parsing any newline character

### DIFF
--- a/code/spc_io/low_level/headers/logstc.py
+++ b/code/spc_io/low_level/headers/logstc.py
@@ -1,3 +1,4 @@
+import re
 from ctypes import addressof, c_char, c_uint8, c_uint32, sizeof, string_at
 from typing import Dict, Union
 
@@ -8,8 +9,7 @@ from spc_io.misc import Structure
 class LogBookBase:
     def txt_as_dict(self):
         return dict([i.decode(errors='surrogateescape').split('=')
-                     for ii in self.txt.split(b'\r\n')
-                     for i in ii.split(b'\n\r')
+                     for i in re.split(rb'[\r\n]+', self.txt)
                      if b'=' in i
                      ])
 


### PR DESCRIPTION
This pull request includes a couple of changes to the `code/spc_io/low_level/headers/logstc.py` file to improve the parsing of text in the `LogBookBase` class.

Background: Some IR spectra files may be generated on UNIX systems, which use the newline character `\n`, as opposed to `\r\n` or `\n\r` commonly found in Windows environments.
For example, a file generated on a UNIX system utilizes the newline character `\n`:

`b'Date=2024-01-12 10:32:12\nUser=---\nName=Isoprop\nComment=InstrumentSn 15429574; SoftwareVersion 2.5.4; MeasuringCell ATR; MeasuringModuleSn 87251253; TransmissionCell ---; PathLength ---;ExportTimestamp: 2024-01-14 15:10:52\nRE=2\nSCANS=32\nZeroPadding=1'
`
This PR enhances the parsing of newline characters by implementing re.split, allowing for the recognition of any combination of `\r` and `\n`. This change ensures that the parser can handle files generated across different operating systems more effectively.

Improvements:
* [`code/spc_io/low_level/headers/logstc.py`](diffhunk://#diff-2f81e9f5a2d2416f1db1e612c736b4b749e31557d876e1cdd6a03f308746942aR1): Added the `re` module import.
* [`code/spc_io/low_level/headers/logstc.py`](diffhunk://#diff-2f81e9f5a2d2416f1db1e612c736b4b749e31557d876e1cdd6a03f308746942aL11-R12): Modified the `txt_as_dict` method to use `re.split` for splitting the text.